### PR TITLE
Fix for fatal error when retrieving model with Soft Delete

### DIFF
--- a/src/Support/Livewire/Concerns/HasCrud.php
+++ b/src/Support/Livewire/Concerns/HasCrud.php
@@ -2,6 +2,8 @@
 
 namespace Uteq\Move\Support\Livewire\Concerns;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 trait HasCrud
 {
     public $confirmingDestroy = null;
@@ -14,7 +16,11 @@ trait HasCrud
 
     private function modelById($id)
     {
-        return $this->resource()->newModel()->find($id);
+        $resourceModel = $this->resource()->model();
+        if(true === in_array(SoftDeletes::class, class_uses($resourceModel), true)) {
+            $resourceModel = $resourceModel->withTrashed();
+        }
+        return $resourceModel->find($id);
     }
 
     public function show($id)


### PR DESCRIPTION
Throws "Missing required parameter for [Route: move.show] [URI: move/{resource}/{model}/show] [Missing parameter: model]. " because the model record cannot be retrieved when using soft delete.